### PR TITLE
Fix long titles

### DIFF
--- a/src/pages/dataset-detail-view/dataset-detail-view.scss
+++ b/src/pages/dataset-detail-view/dataset-detail-view.scss
@@ -22,6 +22,7 @@ dataset-view {
   .name {
     @include header();
     margin-bottom: 0.5rem;
+    width: 65%;
   }
 
   .table-of-contents a {


### PR DESCRIPTION
smartcitiesdata/react_discovery_ui#na

co-authored-by: Jake Clark <jake.clark@gmail.com>

This fixes dataset details views where visualize and download buttons are on separate lines.