### PR TITLE
Auth0 all the things

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcitiesdata/react-discovery-ui",
-  "version": "0.4.18",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7730,8 +7730,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7755,15 +7754,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7780,22 +7777,19 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7926,8 +7920,7 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7941,7 +7934,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7958,7 +7950,6 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7967,15 +7958,13 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7996,7 +7985,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8085,8 +8073,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8100,7 +8087,6 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8196,8 +8182,7 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8239,7 +8224,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8261,7 +8245,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8310,15 +8293,13 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcitiesdata/react-discovery-ui",
-  "version": "0.4.19",
+  "version": "0.5.0",
   "description": "React component for dataset discovery UI",
   "main": "./lib/ReactDiscoveryUI.js",
   "repository": {

--- a/src/auth/auth0-wrapper.js
+++ b/src/auth/auth0-wrapper.js
@@ -27,7 +27,7 @@ const withAuth0 = WrappedComponent => {
       await client.handleRedirectCallback()
       setAuthenticated(true)
       setLoading(false)
-    };
+    }
 
     const auth0Props = {
       loginWithRedirect: (...p) => auth0Client.loginWithRedirect(...p),

--- a/src/auth/auth0-wrapper.js
+++ b/src/auth/auth0-wrapper.js
@@ -22,11 +22,11 @@ const withAuth0 = WrappedComponent => {
     }, [])
 
     const handleRedirectCallback = async () => {
-      setLoading(true);
+      setLoading(true)
       const client = await Auth0ClientProvider.get()
-      await client.handleRedirectCallback();
-      setAuthenticated(true);
-      setLoading(false);
+      await client.handleRedirectCallback()
+      setAuthenticated(true)
+      setLoading(false)
     };
 
     const auth0Props = {
@@ -37,7 +37,7 @@ const withAuth0 = WrappedComponent => {
       isLoading
     }
 
-    return <WrappedComponent auth0={auth0Props} {...props} />
+    return <WrappedComponent auth={auth0Props} {...props} />
   }
 
   return Auth0Wrapper

--- a/src/auth/auth0-wrapper.js
+++ b/src/auth/auth0-wrapper.js
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react"
+import Auth0ClientProvider from '../auth/auth0-client-provider'
+
+const withAuth0 = WrappedComponent => {
+  const Auth0Wrapper = props => {
+    const [isAuthenticated, setAuthenticated] = useState()
+    const [isLoading, setLoading] = useState()
+    const [auth0Client, setAuth0Client] = useState()
+
+    useEffect(() => {
+      const connectAuth0 = async () => {
+        setLoading(true)
+        const client = await Auth0ClientProvider.get()
+        setAuth0Client(client)
+
+        const authenticated = await client.isAuthenticated()
+        setAuthenticated(authenticated)
+        setLoading(false)
+      }
+
+      connectAuth0()
+    }, [])
+
+    const handleRedirectCallback = async () => {
+      setLoading(true);
+      const client = await Auth0ClientProvider.get()
+      await client.handleRedirectCallback();
+      setAuthenticated(true);
+      setLoading(false);
+    };
+
+    const auth0Props = {
+      loginWithRedirect: (...p) => auth0Client.loginWithRedirect(...p),
+      logout: (...p) => auth0Client.logout(...p),
+      handleRedirectCallback,
+      isAuthenticated,
+      isLoading
+    }
+
+    return <WrappedComponent auth0={auth0Props} {...props} />
+  }
+
+  return Auth0Wrapper
+}
+
+export default withAuth0

--- a/src/auth/auth0-wrapper.test.js
+++ b/src/auth/auth0-wrapper.test.js
@@ -51,14 +51,14 @@ describe('Auth0 wrapper component', () => {
 
   it('passes a loading flag', () => {
     const wrapped = subject.find(Wrapped)
-    expect(wrapped.props().auth0.isLoading).not.toBeUndefined()
+    expect(wrapped.props().auth.isLoading).not.toBeUndefined()
   })
 
   it('eventually passes the authenticated flag to the wrapped component', done => {
     setTimeout(() => {
       subject.update()
       const wrapped = subject.find(Wrapped)
-      expect(wrapped.props().auth0.isAuthenticated).toBe(false)
+      expect(wrapped.props().auth.isAuthenticated).toBe(false)
       done()
     })
   })
@@ -67,12 +67,12 @@ describe('Auth0 wrapper component', () => {
     it('sets authenticated to true when called', done => {
       let wrapped = subject.find(Wrapped)
 
-      wrapped.props().auth0.handleRedirectCallback()
+      wrapped.props().auth.handleRedirectCallback()
 
       setTimeout(() => {
         subject.update()
         wrapped = subject.find(Wrapped)
-        expect(wrapped.props().auth0.isAuthenticated).toBe(true)
+        expect(wrapped.props().auth.isAuthenticated).toBe(true)
         done()
       })
     })

--- a/src/auth/auth0-wrapper.test.js
+++ b/src/auth/auth0-wrapper.test.js
@@ -1,0 +1,81 @@
+import { mount } from 'enzyme'
+import { default as createAuth0Client } from '@auth0/auth0-spa-js'
+import withAuth0 from './auth0-wrapper'
+
+jest.mock('@auth0/auth0-spa-js')
+jest.mock('axios')
+
+const Wrapped = () => <div />
+
+const originalError = console.error
+beforeAll(() => {
+  console.error = (...args) => {
+    if (/Warning.*not wrapped in act/.test(args[0])) {
+      return
+    }
+    originalError.call(console, ...args)
+  }
+})
+
+afterAll(() => {
+  console.error = originalError
+})
+
+describe('Auth0 wrapper component', () => {
+  let subject, Auth0Wrapper
+  let loginWithRedirect, logout
+
+  beforeEach(() => {
+    loginWithRedirect = jest.fn()
+    logout = jest.fn()
+
+    createAuth0Client.mockImplementation(() => Promise.resolve({
+      isAuthenticated: jest.fn(() => Promise.resolve(false)),
+      handleRedirectCallback: jest.fn(() => Promise.resolve({})),
+      loginWithRedirect,
+      logout
+    }))
+
+    Auth0Wrapper = withAuth0(Wrapped)
+    subject = mount(<Auth0Wrapper />)
+  })
+
+  it('initializes the client with the correct values', () => {
+    expect(createAuth0Client).toBeCalledWith({
+      domain: window.AUTH0_DOMAIN,
+      client_id: window.AUTH0_CLIENT_ID,
+      audience: window.AUTH0_AUDIENCE,
+      redirect_uri: `${window.location.origin}/oauth`
+    })
+  })
+
+  it('passes a loading flag', () => {
+    const wrapped = subject.find(Wrapped)
+    expect(wrapped.props().auth0.isLoading).not.toBeUndefined()
+  })
+
+  it('eventually passes the authenticated flag to the wrapped component', done => {
+    setTimeout(() => {
+      subject.update()
+      const wrapped = subject.find(Wrapped)
+      expect(wrapped.props().auth0.isAuthenticated).toBe(false)
+      done()
+    })
+  })
+
+  describe('provided handleRedirectCallback', () => {
+    it('sets authenticated to true when called', done => {
+      let wrapped = subject.find(Wrapped)
+
+      wrapped.props().auth0.handleRedirectCallback()
+
+      setTimeout(() => {
+        subject.update()
+        wrapped = subject.find(Wrapped)
+        expect(wrapped.props().auth0.isAuthenticated).toBe(true)
+        done()
+      })
+    })
+  })
+})
+

--- a/src/components/auth0-login-zone/auth0-login-zone.js
+++ b/src/components/auth0-login-zone/auth0-login-zone.js
@@ -7,8 +7,7 @@ import LoadingElement from '../generic-elements/loading-element'
 
 const returnTo = `${window.location.origin}${routes.oauth}`
 
-//TODO: rename to Auth0LoginZone?
-export const OAuthLoginZone = ({ auth: { isAuthenticated, isLoading, loginWithRedirect, logout}  }) => {
+export const Auth0LoginZone = ({ auth: { isAuthenticated, isLoading, loginWithRedirect, logout}  }) => {
   if (isLoading) {
     return <login-zone><LoadingElement /></login-zone>
   }
@@ -24,7 +23,7 @@ export const OAuthLoginZone = ({ auth: { isAuthenticated, isLoading, loginWithRe
   )
 }
 
-OAuthLoginZone.propTypes = {
+Auth0LoginZone.propTypes = {
   auth: PropTypes.shape({
     loginWithRedirect: PropTypes.func.isRequired,
     logout: PropTypes.func.isRequired,
@@ -33,4 +32,4 @@ OAuthLoginZone.propTypes = {
   }).isRequired,
 }
 
-export default withAuth0(OAuthLoginZone)
+export default withAuth0(Auth0LoginZone)

--- a/src/components/auth0-login-zone/auth0-login-zone.test.js
+++ b/src/components/auth0-login-zone/auth0-login-zone.test.js
@@ -1,5 +1,5 @@
 import { mount } from 'enzyme'
-import { OAuthLoginZone as Component } from './oauth-login-zone'
+import { Auth0LoginZone as Component } from './auth0-login-zone'
 import LoadingElement from '../generic-elements/loading-element'
 
 

--- a/src/components/auth0-login-zone/index.js
+++ b/src/components/auth0-login-zone/index.js
@@ -1,0 +1,3 @@
+import Auth0LoginZone from './auth0-login-zone'
+
+export default Auth0LoginZone

--- a/src/components/login-zone/login-zone.scss
+++ b/src/components/login-zone/login-zone.scss
@@ -6,9 +6,9 @@ login-zone {
   display: flex;
 
   login-svgs-and-text {
-  display: flex;
-  line-height: 2rem;
-  align-items: center;
+    display: flex;
+    line-height: 2rem;
+    align-items: center;
   }
 
   p {
@@ -70,5 +70,10 @@ login-zone {
     text-decoration:underline;
     border:none;
     outline:none;
+  }
+
+  loading-element {
+    width: 2rem;
+    margin: auto;
   }
 }

--- a/src/components/oauth-login/index.js
+++ b/src/components/oauth-login/index.js
@@ -1,3 +1,0 @@
-import OAuthLoginZone from './oauth-login-zone'
-
-export default OAuthLoginZone

--- a/src/components/oauth-login/oauth-login-zone.js
+++ b/src/components/oauth-login/oauth-login-zone.js
@@ -8,7 +8,7 @@ const returnTo = `${window.location.origin}${routes.oauth}`
 
 const OAuthLoginZone = ({ auth0: { isAuthenticated, isLoading, loginWithRedirect, logout}  }) => {
   if (isLoading) {
-    return <login-zone><LoadingElement className='icon' /></login-zone>
+    return <login-zone><LoadingElement /></login-zone>
   }
 
   return (

--- a/src/components/oauth-login/oauth-login-zone.js
+++ b/src/components/oauth-login/oauth-login-zone.js
@@ -8,7 +8,7 @@ import LoadingElement from '../generic-elements/loading-element'
 const returnTo = `${window.location.origin}${routes.oauth}`
 
 //TODO: rename to Auth0LoginZone?
-export const OAuthLoginZone = ({ auth0: { isAuthenticated, isLoading, loginWithRedirect, logout}  }) => {
+export const OAuthLoginZone = ({ auth: { isAuthenticated, isLoading, loginWithRedirect, logout}  }) => {
   if (isLoading) {
     return <login-zone><LoadingElement /></login-zone>
   }
@@ -25,7 +25,7 @@ export const OAuthLoginZone = ({ auth0: { isAuthenticated, isLoading, loginWithR
 }
 
 OAuthLoginZone.propTypes = {
-  auth0: PropTypes.shape({
+  auth: PropTypes.shape({
     loginWithRedirect: PropTypes.func.isRequired,
     logout: PropTypes.func.isRequired,
     isAuthenticated: PropTypes.bool,

--- a/src/components/oauth-login/oauth-login-zone.js
+++ b/src/components/oauth-login/oauth-login-zone.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import '../login-zone/login-zone.scss'
 import LoginSvgsAndText from "../login-zone/login-svgs-and-text"
 import routes from '../../routes'
@@ -6,7 +7,8 @@ import LoadingElement from '../generic-elements/loading-element'
 
 const returnTo = `${window.location.origin}${routes.oauth}`
 
-const OAuthLoginZone = ({ auth0: { isAuthenticated, isLoading, loginWithRedirect, logout}  }) => {
+//TODO: rename to Auth0LoginZone?
+export const OAuthLoginZone = ({ auth0: { isAuthenticated, isLoading, loginWithRedirect, logout}  }) => {
   if (isLoading) {
     return <login-zone><LoadingElement /></login-zone>
   }
@@ -20,6 +22,15 @@ const OAuthLoginZone = ({ auth0: { isAuthenticated, isLoading, loginWithRedirect
       }
     </login-zone>
   )
+}
+
+OAuthLoginZone.propTypes = {
+  auth0: PropTypes.shape({
+    loginWithRedirect: PropTypes.func.isRequired,
+    logout: PropTypes.func.isRequired,
+    isAuthenticated: PropTypes.bool,
+    isLoading: PropTypes.bool
+  }).isRequired,
 }
 
 export default withAuth0(OAuthLoginZone)

--- a/src/components/oauth-login/oauth-login-zone.js
+++ b/src/components/oauth-login/oauth-login-zone.js
@@ -1,11 +1,16 @@
 import '../login-zone/login-zone.scss'
-
 import LoginSvgsAndText from "../login-zone/login-svgs-and-text"
-import routes from '../../routes';
+import routes from '../../routes'
+import withAuth0 from '../../auth/auth0-wrapper'
+import LoadingElement from '../generic-elements/loading-element'
 
 const returnTo = `${window.location.origin}${routes.oauth}`
 
-const OAuthLoginZone = ({ isAuthenticated, loginWithRedirect, logout }) => {
+const OAuthLoginZone = ({ auth0: { isAuthenticated, isLoading, loginWithRedirect, logout}  }) => {
+  if (isLoading) {
+    return <login-zone><LoadingElement className='icon' /></login-zone>
+  }
+
   return (
     <login-zone>
       {
@@ -17,4 +22,4 @@ const OAuthLoginZone = ({ isAuthenticated, loginWithRedirect, logout }) => {
   )
 }
 
-export default OAuthLoginZone
+export default withAuth0(OAuthLoginZone)

--- a/src/components/oauth-login/oauth-login-zone.test.js
+++ b/src/components/oauth-login/oauth-login-zone.test.js
@@ -70,19 +70,19 @@ describe('OauthLoginZone component', () => {
   })
 })
 
-const createSubject = (auth0props = {}) => {
-  const defaultAuth0Props = {
+const createSubject = (authProps = {}) => {
+  const defaultAuthProps = {
     isAuthenticated: false,
     isLoading: false,
     loginWithRedirect: jest.fn(),
     logout: jest.fn()
   }
 
-  const auth0PropsWithDefaults = Object.assign({}, defaultAuth0Props, auth0props)
+  const auth0PropsWithDefaults = Object.assign({}, defaultAuthProps, authProps)
 
   return mount(
     <Component
-      auth0={{
+      auth={{
         isAuthenticated: auth0PropsWithDefaults.isAuthenticated,
         isLoading: auth0PropsWithDefaults.isLoading,
         loginWithRedirect: auth0PropsWithDefaults.loginWithRedirect,

--- a/src/components/oauth-login/oauth-login-zone.test.js
+++ b/src/components/oauth-login/oauth-login-zone.test.js
@@ -1,7 +1,9 @@
 import { mount } from 'enzyme'
-import OauthLoginZone from './oauth-login-zone'
+import { OAuthLoginZone as Component } from './oauth-login-zone'
+import LoadingElement from '../generic-elements/loading-element'
 
-describe('login', () => {
+
+describe('OauthLoginZone component', () => {
   let subject, button, loginHandler, logoutHandler
 
   beforeEach(() => {
@@ -25,6 +27,10 @@ describe('login', () => {
 
       expect(loginHandler).toHaveBeenCalled()
     })
+
+    it('does not have a loading element', () => {
+      expect(subject.find(LoadingElement).length).toBe(0)
+    })
   })
 
   describe('authenticated', () => {
@@ -43,23 +49,45 @@ describe('login', () => {
 
       expect(logoutHandler).toHaveBeenCalledWith({ returnTo: `${window.location.origin}/oauth` })
     })
+
+    it('does not have a loading element', () => {
+      expect(subject.find(LoadingElement).length).toBe(0)
+    })
+  })
+
+  describe('loading', () => {
+    beforeEach(() => {
+      subject = createSubject({ isLoading: true })
+    })
+
+    it('has a loading element', () => {
+      expect(subject.find(LoadingElement).length).toBe(1)
+    })
+
+    it('does not have a button', () => {
+      expect(subject.find('button').length).toBe(0)
+    })
   })
 })
 
-const createSubject = (props = {}) => {
-  const defaultProps = {
+const createSubject = (auth0props = {}) => {
+  const defaultAuth0Props = {
     isAuthenticated: false,
+    isLoading: false,
     loginWithRedirect: jest.fn(),
     logout: jest.fn()
   }
 
-  const propsWithDefaults = Object.assign({}, defaultProps, props)
+  const auth0PropsWithDefaults = Object.assign({}, defaultAuth0Props, auth0props)
 
   return mount(
-    <OauthLoginZone
-      isAuthenticated={propsWithDefaults.isAuthenticated}
-      loginWithRedirect={propsWithDefaults.loginWithRedirect}
-      logout={propsWithDefaults.logout}
+    <Component
+      auth0={{
+        isAuthenticated: auth0PropsWithDefaults.isAuthenticated,
+        isLoading: auth0PropsWithDefaults.isLoading,
+        loginWithRedirect: auth0PropsWithDefaults.loginWithRedirect,
+        logout: auth0PropsWithDefaults.logout
+      }}
     />
   )
 }

--- a/src/pages/dataset-list-view/dataset-list-view.js
+++ b/src/pages/dataset-list-view/dataset-list-view.js
@@ -61,8 +61,6 @@ const DatasetListView = (props) => {
     return <div className="result-count">{`${resultCountText}${resultCountQueryText}`}</div>
   }
 
-  const token = sessionStorage.getItem("api-token")
-
   if (isError) {
     return (
       <ErrorComponent

--- a/src/pages/dataset-list-view/dataset-list-view.js
+++ b/src/pages/dataset-list-view/dataset-list-view.js
@@ -4,12 +4,12 @@ import DatasetList from "../../components/dataset-list"
 import Paginator from "../../components/generic-elements/paginator"
 import Select from "../../components/generic-elements/select"
 import Search from "../../components/generic-elements/search"
-import LoginZone from "../../components/login-zone"
 import FacetSidebar from "../../components/facet-sidebar"
 import ErrorComponent from "../../components/generic-elements/error-component"
 import LoadingElement from "../../components/generic-elements/loading-element"
 import Checkbox from "../../components/generic-elements/checkbox"
 import { SearchParamsManager } from "../../search-params/search-params-manager"
+import OAuthLoginZone from "../../components/oauth-login"
 
 const DatasetListView = (props) => {
   const {
@@ -75,7 +75,7 @@ const DatasetListView = (props) => {
     return (
       <dataset-list-view>
         <div className="left-section">
-          <LoginZone token={token} />
+          <OAuthLoginZone />
           <Checkbox
       clickHandler={searchParamsManager.toggleApiAccessible}
             text="API Accessible"

--- a/src/pages/dataset-list-view/dataset-list-view.js
+++ b/src/pages/dataset-list-view/dataset-list-view.js
@@ -9,7 +9,7 @@ import ErrorComponent from "../../components/generic-elements/error-component"
 import LoadingElement from "../../components/generic-elements/loading-element"
 import Checkbox from "../../components/generic-elements/checkbox"
 import { SearchParamsManager } from "../../search-params/search-params-manager"
-import OAuthLoginZone from "../../components/oauth-login"
+import Auth0LoginZone from '../../components/auth0-login-zone'
 
 const DatasetListView = (props) => {
   const {
@@ -73,7 +73,7 @@ const DatasetListView = (props) => {
     return (
       <dataset-list-view>
         <div className="left-section">
-          <OAuthLoginZone />
+          <Auth0LoginZone />
           <Checkbox
       clickHandler={searchParamsManager.toggleApiAccessible}
             text="API Accessible"

--- a/src/pages/dataset-list-view/dataset-list-view.test.js
+++ b/src/pages/dataset-list-view/dataset-list-view.test.js
@@ -145,8 +145,7 @@ function createSubject(props, queryString = "") {
     toggleApiAccessible: jest.fn(),
     updateSortOrder: jest.fn(),
     updateSearchText: jest.fn(),
-    updatePage: jest.fn(),
-    toggleFactes: jest.fn()
+    updatePage: jest.fn()
   }
 
   const propsWithDefaults = Object.assign({}, defaultProps, props);

--- a/src/pages/dataset-list-view/dataset-list-view.test.js
+++ b/src/pages/dataset-list-view/dataset-list-view.test.js
@@ -1,4 +1,4 @@
-import { shallow, mount } from "enzyme";
+import { shallow } from "enzyme";
 import DatasetListView from "./dataset-list-view";
 import Paginator from "../../components/generic-elements/paginator";
 import Select from "../../components/generic-elements/select";

--- a/src/pages/oauth-view/connector.js
+++ b/src/pages/oauth-view/connector.js
@@ -1,9 +1,10 @@
 import { connect } from 'react-redux'
 import OAuthView from './oauth-view'
 import { oAuthCallLoggedIn } from '../../store/actions'
+import withAuth0 from '../../auth/auth0-wrapper'
 
 const mapDispatchToProps = dispatch => ({
   callLoggedIn: () => dispatch(oAuthCallLoggedIn())
 })
 
-export default connect(null, mapDispatchToProps)(OAuthView)
+export default connect(null, mapDispatchToProps)(withAuth0(OAuthView))

--- a/src/pages/oauth-view/oauth-view.js
+++ b/src/pages/oauth-view/oauth-view.js
@@ -6,7 +6,7 @@ import qs from 'qs'
 import LoadingElement from '../../components/generic-elements/loading-element'
 import PropTypes from 'prop-types'
 
-const hasCodeParameter = search => {
+const hasAuthorizationCodeParameter = search => {
   return qs.parse(search, { ignoreQueryPrefix: true }).hasOwnProperty('code')
 }
 
@@ -21,7 +21,7 @@ const OAuthView = (props) => {
 
   useEffect(() => {
     const onMount = async () => {
-      if (hasCodeParameter(search)) {
+      if (hasAuthorizationCodeParameter(search)) {
         try {
           await handleRedirectCallback()
           callLoggedIn()

--- a/src/pages/oauth-view/oauth-view.js
+++ b/src/pages/oauth-view/oauth-view.js
@@ -14,7 +14,7 @@ const OAuthView = (props) => {
   const {
     callLoggedIn,
     history: {location: { search }},
-    auth0
+    auth: { handleRedirectCallback, isLoading }
   } = props
 
   const [handled, setHandled] = useState(false)
@@ -22,7 +22,7 @@ const OAuthView = (props) => {
   useEffect(() => {
     const onMount = async () => {
       if (hasCodeParameter(search)) {
-          await auth0.handleRedirectCallback()
+          await handleRedirectCallback()
           callLoggedIn()
       }
       setHandled(true)
@@ -33,7 +33,7 @@ const OAuthView = (props) => {
   return (
     <oauth-view>
     {
-      auth0.isLoading || !handled
+      isLoading || !handled
         ? <LoadingElement />
         : <Redirect to={{pathname: routes.root}} />
     }
@@ -44,7 +44,7 @@ const OAuthView = (props) => {
 OAuthView.propTypes = {
   callLoggedIn: PropTypes.func.isRequired,
   history: PropTypes.object.isRequired,
-  auth0: PropTypes.shape({
+  auth: PropTypes.shape({
     handleRedirectCallback: PropTypes.func.isRequired,
     isLoading: PropTypes.bool
   }).isRequired

--- a/src/pages/oauth-view/oauth-view.js
+++ b/src/pages/oauth-view/oauth-view.js
@@ -22,8 +22,10 @@ const OAuthView = (props) => {
   useEffect(() => {
     const onMount = async () => {
       if (hasCodeParameter(search)) {
+        try {
           await handleRedirectCallback()
           callLoggedIn()
+        } catch {}
       }
       setHandled(true)
     }

--- a/src/pages/oauth-view/oauth-view.scss
+++ b/src/pages/oauth-view/oauth-view.scss
@@ -1,0 +1,7 @@
+@import '../../styles/mixins.scss';
+
+oauth-view {
+  loading-element {
+    @include default-loading-icon();
+  }
+}

--- a/src/pages/oauth-view/oauth-view.test.js
+++ b/src/pages/oauth-view/oauth-view.test.js
@@ -36,7 +36,7 @@ describe('OAuth View', () => {
       subject = createSubject({
         callLoggedIn: callLoggedInHandler,
         history,
-        auth0: { handleRedirectCallback }
+        auth: { handleRedirectCallback }
       })
     })
 
@@ -61,7 +61,7 @@ describe('OAuth View', () => {
       subject = createSubject({
         callLoggedIn: callLoggedInHandler,
         history,
-        auth0: { handleRedirectCallback }
+        auth: { handleRedirectCallback }
       })
     })
 
@@ -86,7 +86,7 @@ describe('OAuth View', () => {
       subject = createSubject({
         callLoggedIn: callLoggedInHandler,
         history,
-        auth0: { handleRedirectCallback: jest.fn(() => Promise.reject()) }
+        auth: { handleRedirectCallback: jest.fn(() => Promise.reject()) }
       })
     })
 
@@ -103,7 +103,7 @@ describe('OAuth View', () => {
       history.replace('/oauth')
       subject = createSubject({
         history,
-        auth0: { handleRedirectCallback: jest.fn(() => Promise.reject()), isLoading: true }
+        auth: { handleRedirectCallback: jest.fn(() => Promise.reject()), isLoading: true }
       })
     })
 
@@ -124,7 +124,7 @@ describe('OAuth View', () => {
       history.replace('/oauth')
       subject = createSubject({
         history,
-        auth0: { handleRedirectCallback: jest.fn(() => Promise.reject()), isLoading: false }
+        auth: { handleRedirectCallback: jest.fn(() => Promise.reject()), isLoading: false }
       })
     })
 
@@ -138,11 +138,11 @@ describe('OAuth View', () => {
 })
 
 const createSubject = (props = {}) => {
-  const auth0DefaultProps = { handleRedirectCallback: jest.fn(() => Promise.resolve()) }
+  const authDefaultProps = { handleRedirectCallback: jest.fn(() => Promise.resolve()) }
   const defaultProps = {
     callLoggedIn: jest.fn(),
     history: createMemoryHistory(),
-    auth0: auth0DefaultProps
+    auth: authDefaultProps
   }
 
   const propsWithDefaults = Object.assign({}, defaultProps, props)
@@ -154,7 +154,7 @@ const createSubject = (props = {}) => {
         <OAuthView
           callLoggedIn={propsWithDefaults.callLoggedIn}
           history={propsWithDefaults.history}
-          auth0={propsWithDefaults.auth0}
+          auth={propsWithDefaults.auth}
         />
       </Router>
     )

--- a/src/search-params/search-params-manager.js
+++ b/src/search-params/search-params-manager.js
@@ -96,8 +96,7 @@ SearchParamsManager.propTypes = {
   toggleApiAccessible: PropTypes.func.isRequired,
   updateSortOrder: PropTypes.func.isRequired,
   updateSearchText: PropTypes.func.isRequired,
-  updatePage: PropTypes.func.isRequired,
-  toggleFactes: PropTypes.func.isRequired
+  updatePage: PropTypes.func.isRequired
 }
 
 const withSearchParamsManager = (WrappedComponent) => {

--- a/src/store/sagas/api-invoker.js
+++ b/src/store/sagas/api-invoker.js
@@ -1,6 +1,6 @@
 import { put, call } from 'redux-saga/effects'
 import { displayError } from '../actions'
-import axios from 'axios'
+import { AuthenticatedHTTPClient } from '../../utils/http-clients'
 import qs from 'qs'
 
 const defaultParamFunction = () => ({})
@@ -14,7 +14,7 @@ export default ({ endpoint, actionator, errorAction = displayError(), queryParam
         paramsSerializer: (params) => qs.stringify(params, { arrayFormat: 'brackets' }),
         withCredentials: true
       }
-      const response = yield call(axios.get, endpoint, query)
+      const response = yield call(AuthenticatedHTTPClient.get, endpoint, query)
       if (response.status === 200) {
         yield put(actionator(response.data))
       } else {

--- a/src/store/sagas/api-invoker.test.js
+++ b/src/store/sagas/api-invoker.test.js
@@ -1,12 +1,8 @@
-import { DISPLAY_ERROR } from "../actions";
-import apiInvoker from "./api-invoker";
-import { createStore, applyMiddleware } from "redux";
-import createSagaMiddleware from "redux-saga";
-import mockAxios from "axios";
-import { sessionStorage } from "storage2";
-
-jest.mock("axios");
-jest.mock("storage2");
+import { DISPLAY_ERROR } from "../actions"
+import apiInvoker from "./api-invoker"
+import { createStore, applyMiddleware } from "redux"
+import createSagaMiddleware from "redux-saga"
+import { AuthenticatedHTTPClient } from '../../utils/http-clients'
 
 describe("api-invoker", () => {
   const reducer = (state = [], action) => {
@@ -19,6 +15,8 @@ describe("api-invoker", () => {
   let store, sagaMiddleware, actionator;
 
   beforeEach(() => {
+    AuthenticatedHTTPClient.get = jest.fn()
+
     window.API_HOST = "http://fake.com/";
 
     sagaMiddleware = createSagaMiddleware();
@@ -31,13 +29,13 @@ describe("api-invoker", () => {
   });
 
   it("invokes axios with the correct object when no query parameter function is passed in", () => {
-    mockAxios.get.mockImplementationOnce(() => ({
+    AuthenticatedHTTPClient.get.mockImplementationOnce(() => ({
       status: 200,
       data: []
     }));
     sagaMiddleware.run(apiInvoker({ endpoint: "/gohome", actionator }));
 
-    expect(mockAxios.get).toHaveBeenCalledWith("/gohome", {
+    expect(AuthenticatedHTTPClient.get).toHaveBeenCalledWith("/gohome", {
       baseURL: window.API_HOST,
       params: {},
       paramsSerializer: expect.anything(),
@@ -48,7 +46,7 @@ describe("api-invoker", () => {
   it("passes query parameters when passed in", () => {
     const mockQueryParam = { some: "param" };
     const queryParameterBuilder = jest.fn().mockReturnValue(mockQueryParam);
-    mockAxios.get.mockImplementationOnce(() => ({
+    AuthenticatedHTTPClient.get.mockImplementationOnce(() => ({
       status: 200,
       data: []
     }));
@@ -56,7 +54,7 @@ describe("api-invoker", () => {
       apiInvoker({ endpoint: "my-url", actionator, queryParameterBuilder })
     );
 
-    expect(mockAxios.get).toHaveBeenCalledWith("my-url", {
+    expect(AuthenticatedHTTPClient.get).toHaveBeenCalledWith("my-url", {
       baseURL: window.API_HOST,
       params: mockQueryParam,
       paramsSerializer: expect.anything(),
@@ -67,7 +65,7 @@ describe("api-invoker", () => {
   it("gets query parameters from the query param function", () => {
     const mockEvent = { type: "some type" };
     const queryParameterBuilder = jest.fn();
-    mockAxios.get.mockImplementationOnce(() => ({
+    AuthenticatedHTTPClient.get.mockImplementationOnce(() => ({
       status: 200,
       data: []
     }));
@@ -80,7 +78,7 @@ describe("api-invoker", () => {
   });
 
   it("calls actionator when successful", () => {
-    mockAxios.get.mockImplementationOnce(() => ({
+    AuthenticatedHTTPClient.get.mockImplementationOnce(() => ({
       status: 200,
       data: fakeDataSetResponse
     }));
@@ -93,7 +91,7 @@ describe("api-invoker", () => {
   it("dispatches a display error by default when the network fails with an error", () => {
     console.error = jest.fn();
     const expectedError = new Error("Network error");
-    mockAxios.get.mockImplementationOnce(() => {
+    AuthenticatedHTTPClient.get.mockImplementationOnce(() => {
       throw expectedError;
     });
 
@@ -106,7 +104,7 @@ describe("api-invoker", () => {
   });
 
   it("dispatches a display error by default if the status code is not 200", () => {
-    mockAxios.get.mockImplementationOnce(() => ({
+    AuthenticatedHTTPClient.get.mockImplementationOnce(() => ({
       status: 421,
       data: fakeDataSetResponse
     }));
@@ -119,7 +117,7 @@ describe("api-invoker", () => {
   });
 
   it("dispatches provided errorAction when the network fails with an error", () => {
-    mockAxios.get.mockImplementationOnce(() => {
+    AuthenticatedHTTPClient.get.mockImplementationOnce(() => {
       throw new Error("Network error");
     });
 
@@ -129,7 +127,7 @@ describe("api-invoker", () => {
   });
 
   it("dispatches provided errorAction if the status code is not 200", () => {
-    mockAxios.get.mockImplementationOnce(() => ({
+    AuthenticatedHTTPClient.get.mockImplementationOnce(() => ({
       status: 421,
       data: fakeDataSetResponse
     }));

--- a/src/store/sagas/dataset-list-saga.js
+++ b/src/store/sagas/dataset-list-saga.js
@@ -1,5 +1,5 @@
 import { takeEvery } from 'redux-saga/effects'
-import { DATASET_SEARCH, datasetSearchSucceeded, displayError } from '../actions'
+import { DATASET_SEARCH, datasetSearchSucceeded } from '../actions'
 import apiInvoker from './api-invoker'
 
 export default function * theRealDatasetSaga () {

--- a/src/store/sagas/dataset-list-saga.test.js
+++ b/src/store/sagas/dataset-list-saga.test.js
@@ -2,11 +2,9 @@ import {
   datasetSearch
 } from '../actions'
 import theRealDatasetSaga  from './dataset-list-saga'
-import mockAxios from 'axios'
 import { createStore, applyMiddleware } from 'redux'
 import createSagaMiddleware from 'redux-saga'
-
-jest.mock('axios')
+import { AuthenticatedHTTPClient } from '../../utils/http-clients'
 
 const setUpSagaMiddleware = reducer => {
   const sagaMiddleware = createSagaMiddleware()
@@ -19,6 +17,8 @@ const setUpSagaMiddleware = reducer => {
 describe('dataset-list-saga', () => {
   describe('success', () => {
     it('calls api with query', () => {
+      AuthenticatedHTTPClient.get = jest.fn()
+
       const actionTrackingReducer = (state = [], action) => {
         return [...state, action]
       }
@@ -33,7 +33,7 @@ describe('dataset-list-saga', () => {
       }
 
       window.API_HOST = 'http://example.com/'
-      mockAxios.get.mockImplementationOnce(() => (response))
+      AuthenticatedHTTPClient.get.mockImplementationOnce(() => (response))
       const store = setUpSagaMiddleware(actionTrackingReducer)
 
       const params = {
@@ -59,7 +59,7 @@ describe('dataset-list-saga', () => {
         apiAccessible: true
       }
 
-      expect(mockAxios.get).toHaveBeenCalledWith(
+      expect(AuthenticatedHTTPClient.get).toHaveBeenCalledWith(
         '/api/v1/dataset/search',
         expect.objectContaining({
           baseURL: window.API_HOST,

--- a/src/store/sagas/freestyle-query-saga.js
+++ b/src/store/sagas/freestyle-query-saga.js
@@ -43,7 +43,7 @@ function* executeQuery({ queryText }) {
   }
 }
 
-const cancelQuery = function* (_action) {
+const cancelQuery = function* () {
   const cancelToken = yield select(getDatasetQueryCancelToken)
   return cancelToken.cancel(cancelMessage)
 }

--- a/src/store/sagas/freestyle-query-saga.js
+++ b/src/store/sagas/freestyle-query-saga.js
@@ -1,15 +1,14 @@
 import { takeEvery, put, call, select } from 'redux-saga/effects'
 import { EXECUTE_FREESTYLE_QUERY, CANCEL_FREESTYLE_QUERY, setQuerySuccess, setQueryFailure, setQueryInProgress } from '../actions'
 import { getDatasetQueryCancelToken } from '../selectors'
-import axios from 'axios'
+import { AuthenticatedHTTPClient } from '../../utils/http-clients'
 import { getFreestyleQueryText } from '../query-selectors'
 
 const cancelMessage = 'Your query has been stopped'
 const failureMessage = 'Query failure.  There may be a syntax issue.'
 
 function* executeQuery({ queryText }) {
-  const CancelToken = axios.CancelToken
-  const cancelToken = CancelToken.source()
+  const cancelToken = AuthenticatedHTTPClient.cancelTokenSource()
 
   let queryBody
   if (queryText) {
@@ -21,7 +20,7 @@ function* executeQuery({ queryText }) {
   yield put(setQueryInProgress(cancelToken))
   try {
     const response = yield call(
-      axios.post,
+      AuthenticatedHTTPClient.post,
       '/api/v1/query',
       queryBody,
       {

--- a/src/store/sagas/freestyle-query-saga.test.js
+++ b/src/store/sagas/freestyle-query-saga.test.js
@@ -10,6 +10,7 @@ import freestyleQuerySaga from './freestyle-query-saga'
 import mockAxios from 'axios'
 import { createStore, applyMiddleware } from 'redux'
 import createSagaMiddleware from 'redux-saga'
+import { AuthenticatedHTTPClient } from '../../utils/http-clients'
 import oneTrueReducer from '../reducers'
 
 jest.mock('axios')
@@ -39,6 +40,7 @@ describe('freestyle-query-saga', () => {
 
   beforeEach(() => {
     window.API_HOST = 'http://example.com/'
+    AuthenticatedHTTPClient.post = jest.fn()
 
     mockAxios.CancelToken = { source: () => ({ token: {} }) }
   })
@@ -49,13 +51,13 @@ describe('freestyle-query-saga', () => {
 
   describe('success', () => {
     beforeEach(() => {
-      mockAxios.post.mockImplementationOnce(() => (response))
+      AuthenticatedHTTPClient.post.mockImplementationOnce(() => (response))
       store = setUpSagaMiddleware(actionTrackingReducer)
       store.dispatch(executeFreestyleQuery(queryText))
     })
 
     it('calls multiple query api with query', () => {
-      expect(mockAxios.post).toHaveBeenCalledWith('/api/v1/query', queryText, {
+      expect(AuthenticatedHTTPClient.post).toHaveBeenCalledWith('/api/v1/query', queryText, {
         cancelToken: expect.any(Object),
         baseURL: window.API_HOST,
         withCredentials: true,
@@ -84,7 +86,7 @@ describe('freestyle-query-saga', () => {
         status: 400,
         data
       }
-      mockAxios.post.mockImplementationOnce(() => (response))
+      AuthenticatedHTTPClient.post.mockImplementationOnce(() => (response))
 
       store.dispatch(executeFreestyleQuery(queryText))
 
@@ -94,7 +96,7 @@ describe('freestyle-query-saga', () => {
     it('dispatches a QUERY_DATASET_FAILED event on a catastrophic failure', () => {
       const errorMsg = "It's all over"
 
-      mockAxios.post.mockImplementationOnce(() => { throw new Error(errorMsg) })
+      AuthenticatedHTTPClient.post.mockImplementationOnce(() => { throw new Error(errorMsg) })
 
       store.dispatch(executeFreestyleQuery(queryText))
 
@@ -107,14 +109,14 @@ describe('freestyle-query-saga', () => {
     beforeEach(() => {
       store = setUpSagaMiddleware(oneTrueReducer)
 
-      mockAxios.post.mockImplementationOnce(() => (response))
+      AuthenticatedHTTPClient.post.mockImplementationOnce(() => (response))
 
       store.dispatch(setQueryText(queryTextInStore))
       store.dispatch(executeFreestyleQuery())
     })
 
     it('calls multiple query api with the query from store', () => {
-      expect(mockAxios.post).toHaveBeenCalledWith('/api/v1/query', queryTextInStore, {
+      expect(AuthenticatedHTTPClient.post).toHaveBeenCalledWith('/api/v1/query', queryTextInStore, {
         cancelToken: expect.any(Object),
         baseURL: window.API_HOST,
         withCredentials: true,

--- a/src/store/sagas/freestyle-query-saga.test.js
+++ b/src/store/sagas/freestyle-query-saga.test.js
@@ -7,13 +7,10 @@ import {
   setQueryText
 } from '../actions'
 import freestyleQuerySaga from './freestyle-query-saga'
-import mockAxios from 'axios'
 import { createStore, applyMiddleware } from 'redux'
 import createSagaMiddleware from 'redux-saga'
 import { AuthenticatedHTTPClient } from '../../utils/http-clients'
 import oneTrueReducer from '../reducers'
-
-jest.mock('axios')
 
 const ERROR_MESSAGE_CONSTANT = 'Query failure.  There may be a syntax issue.'
 
@@ -41,8 +38,7 @@ describe('freestyle-query-saga', () => {
   beforeEach(() => {
     window.API_HOST = 'http://example.com/'
     AuthenticatedHTTPClient.post = jest.fn()
-
-    mockAxios.CancelToken = { source: () => ({ token: {} }) }
+    AuthenticatedHTTPClient.cancelTokenSource = jest.fn(() => ({ token: {} }))
   })
 
   afterEach(() => {
@@ -133,8 +129,7 @@ describe('freestyle-query-saga QUERY_DATASET_CANCELLED event', () => {
 
   beforeEach(() => {
     store = setUpSagaMiddleware(oneTrueReducer)
-
-    mockAxios.CancelToken = { source: () => ({ token: {} }) }
+    AuthenticatedHTTPClient.cancelTokenSource = jest.fn(() => ({ token: {} }))
 
     cancelMock = jest.fn()
     const cancelToken = { token: {}, cancel: cancelMock }

--- a/src/utils/http-clients.js
+++ b/src/utils/http-clients.js
@@ -6,7 +6,7 @@ class AuthenticatedHTTPClient {
     const config = {baseURL: window.API_HOST, headers: {}, validateStatus: false}
     const authClient = await Auth0Client.get()
     const isAuthenticated = await authClient.isAuthenticated()
-    
+
     if(isAuthenticated) {
       const token = await authClient.getTokenSilently()
       config.headers = Object.assign({}, config.headers, {'Authorization': `Bearer ${token}`})

--- a/src/utils/http-clients.js
+++ b/src/utils/http-clients.js
@@ -2,6 +2,10 @@ import axios from 'axios'
 import Auth0Client from '../auth/auth0-client-provider'
 
 class AuthenticatedHTTPClient {
+  static cancelTokenSource() {
+    return axios.CancelToken.source()
+  }
+
   static async initializeClient() {
     const config = {baseURL: window.API_HOST, headers: {}, validateStatus: false}
     const authClient = await Auth0Client.get()


### PR DESCRIPTION
This PR officially switches discovery UI to use auth0 for all authentication.

There will be a future card to make it 'configurable' - allowing us to still use default (Discovery API LDAP) auth in addition to Auth0.

As part of this effort we created a new higher-order component for exposing auth details to react components (`auth0-wrapper.js`)