### PR TITLE
updating websocket consumer example

### DIFF
--- a/src/components/streaming-api-doc/streaming-api-doc.js
+++ b/src/components/streaming-api-doc/streaming-api-doc.js
@@ -18,16 +18,19 @@ export default class extends Component {
       <div>
         <div className='example-container'>
           <div className='example-header'>
-            Example using <a href='https://github.com/esphen/wsta'>WSTA</a> on a terminal
+            Example using <a href='https://github.com/vi/websocat'>Websocat</a> on a terminal
             </div>
           <div className='example-code'>
-            <code>{`
-                              wsta -I --ping 50 --ping-msg
-                              '{"topic": "phoenix","event":"heartbeat","payload":{},"ref":"1"}'
-                              'wss://streams.${window.BASE_URL}/socket/websocket'
-                              '{"topic": "streaming:${systemName}","event":"phx_join","payload":{},"ref":"1"}'
-                          `}
+            <code>
+              <div>{`websocat wss://streams.${window.BASE_URL}/socket/websocket`}</div>
+              <div>{`'{"topic": "streaming:${systemName}","event":"phx_join","payload":{},"ref":"1"}'`}</div>
             </code>
+          </div>
+          <div className='example-header'>
+              Phoenix Channels clients
+          </div>
+          <div>
+            For application development, look at the <a href="https://www.npmjs.com/package/phoenix">official Phoenix Javascript library</a>, or one of the <a href="https://hexdocs.pm/phoenix/channels.html#client-libraries">other client libraries</a>
           </div>
         </div>
       </div>

--- a/src/components/streaming-api-doc/streaming-api-doc.js
+++ b/src/components/streaming-api-doc/streaming-api-doc.js
@@ -30,7 +30,7 @@ export default class extends Component {
               Phoenix Channels clients
           </div>
           <div>
-            For application development, look at the <a href="https://www.npmjs.com/package/phoenix">official Phoenix Javascript library</a>, or one of the <a href="https://hexdocs.pm/phoenix/channels.html#client-libraries">other client libraries</a>
+            For application development, look at the <a href="https://www.npmjs.com/package/phoenix" target="_blank">official Phoenix Javascript library</a>, or one of the <a href="https://hexdocs.pm/phoenix/channels.html#client-libraries" target="_blank">other client libraries</a>
           </div>
         </div>
       </div>

--- a/src/components/streaming-api-doc/streaming-api-doc.js
+++ b/src/components/streaming-api-doc/streaming-api-doc.js
@@ -23,7 +23,7 @@ export default class extends Component {
           <div className='example-code'>
             <code>
               <div>{`websocat wss://streams.${window.BASE_URL}/socket/websocket`}</div>
-              <div>{`'{"topic": "streaming:${systemName}","event":"phx_join","payload":{},"ref":"1"}'`}</div>
+              <div>{`{"topic": "streaming:${systemName}","event":"phx_join","payload":{},"ref":"1"}`}</div>
             </code>
           </div>
           <div className='example-header'>


### PR DESCRIPTION
WSTA example has not been accurate for some time.
Websocket, also a rust binary installable by users without any particular toolchain, should be a better option and provides a simpler connection string.

Also linking users to the phoenix channels documentation to give developers a better idea of how to consume off a channel socket for programmatic interaction.