### PR TITLE
Create functional tests that workspace is for authenticated users only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ lib/
 *.tgz
 
 cypress/videos
+
+.vscode/

--- a/cypress/integration/saved_visualizations_page_spec.js
+++ b/cypress/integration/saved_visualizations_page_spec.js
@@ -1,0 +1,16 @@
+import { Selectors, Routes as routes } from '../support/visualization_page.js'
+
+const {errorText} = Selectors
+
+describe('Saved visualizations', function () {
+    beforeEach(function () {
+        cy.server()
+        cy.route(routes.info)
+        cy.route(routes.user)
+    })
+
+    it('/user is not accessible to non-logged-in users', function () {
+        cy.visit('/user')
+        cy.get(errorText).contains("You must be signed in to see your saved visualizations")
+    })
+})

--- a/cypress/support/visualization_page.js
+++ b/cypress/support/visualization_page.js
@@ -1,0 +1,16 @@
+export const Selectors = {
+    errorText: '[data-testid=error-text]'
+}
+
+export const Routes = {
+    info: {
+        method: 'GET',
+        url: '/sockjs-node/*',
+        response: 'fixture:info.json'
+    },
+    user: {
+        method: 'GET',
+        url: '/api/v1/visualization',
+        response: []
+    }
+}

--- a/src/components/generic-elements/error-component/error-component.js
+++ b/src/components/generic-elements/error-component/error-component.js
@@ -7,7 +7,7 @@ const ErrorComponent = props => {
     <error-component>
       <div className='error-container'>
         <ErrorOutline className='error-icon' />
-        <div className='error-text'>{props.errorText}</div>
+        <div data-testid="error-text" className='error-text'>{props.errorText}</div>
       </div>
     </error-component>
   )


### PR DESCRIPTION
[Create functional tests that workspace is for authenticated users only](https://github.com/SmartColumbusOS/scosopedia/issues/132)

This card originally tested all of saved visualizations page. But after realizing we couldn't spoof auth0 authentication we decided to test all the authenticated flows in the [end-to-end tests](https://github.com/SmartColumbusOS/scosopedia/issues/148)