### PR TITLE
Added fit-textarea package to react_discovery_ui to fix scrolling issue

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -1,4 +1,4 @@
-window.API_HOST = 'http://localhost:4000'
+window.API_HOST = 'http://data.staging.internal.smartcolumbusos.com'
 window.GTM_ID = ''
 window.BASE_URL = 'example.com'
 window.STREETS_TILE_LAYER_URL = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'

--- a/config/config.js
+++ b/config/config.js
@@ -1,4 +1,4 @@
-window.API_HOST = 'http://data.staging.internal.smartcolumbusos.com'
+window.API_HOST = 'http://localhost:4000'
 window.GTM_ID = ''
 window.BASE_URL = 'example.com'
 window.STREETS_TILE_LAYER_URL = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'

--- a/package-lock.json
+++ b/package-lock.json
@@ -8127,6 +8127,11 @@
         "resolve-dir": "^1.0.1"
       }
     },
+    "fit-textarea": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fit-textarea/-/fit-textarea-2.0.0.tgz",
+      "integrity": "sha512-3Nm69derMr/9EIwIuOqU8yR/SbYI7xBkJ4Vd35AVv1Xto0pQTDPa0lEe5cULrgIEUbPu/lhXBd2eus5cZTqkPA=="
+    },
     "flat-cache": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@material-ui/icons": "^3.0.2",
     "acorn": ">=7.1.1",
     "axios": "^0.19.0",
+    "fit-textarea": "^2.0.0",
     "handlebars": "^4.5.3",
     "leaflet": "^1.5.1",
     "lodash": "^4.17.12",

--- a/src/components/query-form/query-form.js
+++ b/src/components/query-form/query-form.js
@@ -8,16 +8,10 @@ import InfoOutlined from '@material-ui/icons/InfoOutlined'
 import MergeType from '@material-ui/icons/MergeType'
 import _ from 'lodash'
 import { Link } from 'react-router-dom'
+import fitTextarea from 'fit-textarea';
 
 const TEXT_AREA_MIN_HEIGHT = 100;
 const TEXT_AREA_HEIGHT_OFFSET = 5;
-
-const adjustHeight = (element) => {
-  if (element.scrollHeight > TEXT_AREA_MIN_HEIGHT + TEXT_AREA_HEIGHT_OFFSET) {
-    element.style.height = `${TEXT_AREA_HEIGHT_OFFSET}px`
-    element.style.height = `${element.scrollHeight}px`;
-  }
-}
 
 const QueryForm = props => {
   const {
@@ -39,12 +33,12 @@ const QueryForm = props => {
 
   React.useEffect(() => {
     setLocalQueryText(queryText);
-    adjustHeight(textAreaRef.current)
+    const textarea = document.querySelector('.query-input')
+    fitTextarea.watch(textarea)
   }, [queryText])
 
   const handleQueryChange = event => {
     setLocalQueryText(event.target.value)
-    adjustHeight(event.target)
   }
 
   const updateReduxQueryText = e => setQueryText(e.target.value)
@@ -68,6 +62,7 @@ const QueryForm = props => {
     className='query-input'
     ref={textAreaRef}
     data-testid='query-input'
+    rows="3"
   />
   const submitButton = <button data-testid="submit-query-button" className="action-button" disabled={isQueryLoading} onClick={submit}>Submit</button>
   const cancelButton = <button data-testid="cancel-query-button" className="action-button" disabled={!isQueryLoading} onClick={cancel}>Cancel</button>


### PR DESCRIPTION
This is a [bug](https://app.zenhub.com/workspaces/smartcolumbusos-5d08f55f08ccbe75911ce796/issues/smartcolumbusos/scosopedia/203) fix.

If the query box in the 'Write SQL' page of react_discovery_ui is sufficiently large typing in the query box will change the scroll position on the page making it "jump".

The [fix-textarea](https://www.npmjs.com/package/fit-textarea) npm package handles this jump by watching the textarea.

the rows attribute gives the textarea a default height.