### PR TITLE
fixed scrolling issue with react-autosize-textarea

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartcitiesdata/react-discovery-ui",
-  "version": "1.2.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3139,6 +3139,11 @@
         }
       }
     },
+    "autosize": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/autosize/-/autosize-4.0.2.tgz",
+      "integrity": "sha512-jnSyH2d+qdfPGpWlcuhGiHmqBJ6g3X+8T+iRwFrHPLVcdoGJE/x6Qicm6aDHfTsbgZKxyV8UU/YB2p4cjKDRRA=="
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -4730,6 +4735,11 @@
         "validate.io-ndarray-like": "^1.0.0",
         "validate.io-positive-integer": "^1.0.0"
       }
+    },
+    "computed-style": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/computed-style/-/computed-style-0.1.4.tgz",
+      "integrity": "sha1-fzRP2FhLLkJb7cpKGvwOMAuwXXQ="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -12903,6 +12913,14 @@
         "type-check": "~0.3.2"
       }
     },
+    "line-height": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/line-height/-/line-height-0.3.1.tgz",
+      "integrity": "sha1-SxIF7d4YKHKl76PI9iCzGHqcVMk=",
+      "requires": {
+        "computed-style": "~0.1.3"
+      }
+    },
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -16725,6 +16743,16 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
         "scheduler": "^0.13.6"
+      }
+    },
+    "react-autosize-textarea": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-7.1.0.tgz",
+      "integrity": "sha512-BHpjCDkuOlllZn3nLazY2F8oYO1tS2jHnWhcjTWQdcKiiMU6gHLNt/fzmqMSyerR0eTdKtfSIqtSeTtghNwS+g==",
+      "requires": {
+        "autosize": "^4.0.2",
+        "line-height": "^0.3.1",
+        "prop-types": "^15.5.6"
       }
     },
     "react-base16-styling": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "prop-types": "^15.6.0",
     "qs": "^6.7.0",
     "react": "~16.8.6",
+    "react-autosize-textarea": "^7.1.0",
     "react-chart-editor": "^0.40.1",
     "react-collapse": "^4.0.3",
     "react-copy-to-clipboard": "^5.0.1",

--- a/src/components/query-form/query-form.js
+++ b/src/components/query-form/query-form.js
@@ -8,16 +8,10 @@ import InfoOutlined from '@material-ui/icons/InfoOutlined'
 import MergeType from '@material-ui/icons/MergeType'
 import _ from 'lodash'
 import { Link } from 'react-router-dom'
+import TextareaAutosize from 'react-autosize-textarea'
 
 const TEXT_AREA_MIN_HEIGHT = 100;
 const TEXT_AREA_HEIGHT_OFFSET = 5;
-
-const adjustHeight = (element) => {
-  if (element.scrollHeight > TEXT_AREA_MIN_HEIGHT + TEXT_AREA_HEIGHT_OFFSET) {
-    element.style.height = `${TEXT_AREA_HEIGHT_OFFSET}px`
-    element.style.height = `${element.scrollHeight}px`;
-  }
-}
 
 const QueryForm = props => {
   const {
@@ -39,12 +33,10 @@ const QueryForm = props => {
 
   React.useEffect(() => {
     setLocalQueryText(queryText);
-    adjustHeight(textAreaRef.current)
   }, [queryText])
 
   const handleQueryChange = event => {
     setLocalQueryText(event.target.value)
-    adjustHeight(event.target)
   }
 
   const updateReduxQueryText = e => setQueryText(e.target.value)
@@ -57,7 +49,7 @@ const QueryForm = props => {
     cancelQuery()
   }
 
-  const textArea = <textarea
+  const textArea = <TextareaAutosize
     style={{ minHeight: `${TEXT_AREA_MIN_HEIGHT}px` }}
     type='text'
     placeholder='SELECT * FROM ...'
@@ -68,6 +60,7 @@ const QueryForm = props => {
     className='query-input'
     ref={textAreaRef}
     data-testid='query-input'
+    rows={3}
   />
   const submitButton = <button data-testid="submit-query-button" className="action-button" disabled={isQueryLoading} onClick={submit}>Submit</button>
   const cancelButton = <button data-testid="cancel-query-button" className="action-button" disabled={!isQueryLoading} onClick={cancel}>Cancel</button>

--- a/src/components/query-form/query-form.test.js
+++ b/src/components/query-form/query-form.test.js
@@ -120,14 +120,14 @@ describe('QueryForm', () => {
       queryInput = subject.find('textarea')
     })
 
-    it('it expands the text area height to avoid scrolling', () => {
-      const scrollHeight = 106
-      let element = { scrollHeight, style: {}, value: 'some really long multi-line query' }
+    // it('it expands the text area height to avoid scrolling', () => {
+    //   const scrollHeight = 106
+    //   let element = { scrollHeight, style: {}, value: 'some really long multi-line query' }
 
-      queryInput.simulate('change', { target: element });
+    //   queryInput.simulate('change', { target: element });
 
-      expect(element.style.height).toBe(`${scrollHeight}px`)
-    })
+    //   expect(element.style.height).toBe(`${scrollHeight}px`)
+    // })
 
     it('does not adjust the test area height below the minimum height', () => {
       const scrollHeight = 105

--- a/src/components/query-form/query-form.test.js
+++ b/src/components/query-form/query-form.test.js
@@ -112,33 +112,6 @@ describe('QueryForm', () => {
     })
   })
 
-  describe('when the query changes locally', () => {
-    let queryInput
-    beforeEach(() => {
-      subject = createSubject({})
-
-      queryInput = subject.find('textarea')
-    })
-
-    // it('it expands the text area height to avoid scrolling', () => {
-    //   const scrollHeight = 106
-    //   let element = { scrollHeight, style: {}, value: 'some really long multi-line query' }
-
-    //   queryInput.simulate('change', { target: element });
-
-    //   expect(element.style.height).toBe(`${scrollHeight}px`)
-    // })
-
-    it('does not adjust the test area height below the minimum height', () => {
-      const scrollHeight = 105
-      let element = { scrollHeight, style: {}, value: '' }
-
-      queryInput.simulate('change', { target: element })
-
-      expect(element.style.height).toBeFalsy()
-    })
-  })
-
   describe('on success', () => {
     beforeEach(() => {
       subject = createSubject({ isQueryLoading: false, isQueryLoaded: true, isQueryDataAvailable: true })


### PR DESCRIPTION
This is a [bug](https://app.zenhub.com/workspaces/smartcolumbusos-5d08f55f08ccbe75911ce796/issues/smartcolumbusos/scosopedia/203) fix

If the query box in the 'Write SQL' page of react_discovery_ui is sufficiently large typing in the query box will change the scroll position on the page making it "jump".

The [react-autosize-textarea](https://www.npmjs.com/package/react-autosize-textarea) is a react component: TextareaAutosize that deals with this issue.

the rows attribute gives the textarea a default height.